### PR TITLE
Add Docker Compose setup for local development (fixes #2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Database Configuration
+POSTGRES_DB=chefify
+POSTGRES_USER=chefify_user
+POSTGRES_PASSWORD=chefify_password
+
+# API Configuration
+ASPNETCORE_ENVIRONMENT=Development
+ASPNETCORE_URLS=http://+:5000
+ConnectionStrings__DefaultConnection=Host=database;Port=5432;Database=chefify;Username=chefify_user;Password=chefify_password;
+
+# OIDC Configuration
+OIDC__Authority=https://your-oidc-provider.com
+OIDC__ClientId=chefify-api
+OIDC__ClientSecret=your-client-secret
+
+# Frontend Configuration
+REACT_APP_API_URL=http://localhost:5000
+CHOKIDAR_USEPOLLING=true

--- a/README.md
+++ b/README.md
@@ -15,11 +15,62 @@ Chefify is a comprehensive recipe management application that combines recipe or
 
 ## Getting Started
 
-*Coming soon...*
+### Prerequisites
+
+- Docker and Docker Compose
+- Git
+
+### Local Development Setup
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/Dionmm/Chefify.git
+   cd Chefify
+   ```
+
+2. Copy the environment variables template:
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Update the `.env` file with your specific configuration values (especially OIDC settings).
+
+4. Start the development environment:
+   ```bash
+   docker-compose up --build
+   ```
+
+5. The application will be available at:
+   - Frontend: http://localhost:3000
+   - API: http://localhost:5000
+   - Database: localhost:5432
+
+### Development Services
+
+- **PostgreSQL 15**: Database with recipe schema pre-loaded
+- **.NET 8 API**: Backend API with hot reload support
+- **React Frontend**: Frontend application with hot reload support
+
+### Hot Reload
+
+The development setup includes hot reload for both backend and frontend:
+- Backend: Uses `dotnet watch` for automatic rebuilds
+- Frontend: Uses React development server with file watching
+
+### Database
+
+The PostgreSQL database is initialized with:
+- Chefify-specific schema from `recipes.sql`
+- Basic extensions and configuration from `database/init.sql`
+- Persistent data storage via Docker volumes
 
 ## Technologies
 
-*To be determined based on implementation choices*
+- **Backend**: .NET 8 with Clean Architecture
+- **Frontend**: React 18
+- **Database**: PostgreSQL 15
+- **Development**: Docker Compose for local development
+- **Authentication**: OIDC integration ready
 
 ## Contributing
 

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,33 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+# Install dotnet watch tool
+RUN dotnet tool install --global dotnet-watch
+
+# Set working directory
+WORKDIR /app
+
+# Copy solution and project files for restore
+COPY *.sln ./
+COPY Directory.Build.props ./
+COPY Chefify.Api/*.csproj ./Chefify.Api/
+COPY Chefify.Application/*.csproj ./Chefify.Application/
+COPY Chefify.Core/*.csproj ./Chefify.Core/
+COPY Chefify.Infrastructure/*.csproj ./Chefify.Infrastructure/
+COPY Chefify.Tests/*.csproj ./Chefify.Tests/
+
+# Restore dependencies
+RUN dotnet restore
+
+# Copy the rest of the source code
+COPY . .
+
+# Expose port
+EXPOSE 5000
+
+# Set environment variables for development
+ENV ASPNETCORE_ENVIRONMENT=Development
+ENV ASPNETCORE_URLS=http://+:5000
+
+# Start the API with hot reload
+WORKDIR /app/Chefify.Api
+CMD ["dotnet", "watch", "run", "--urls", "http://0.0.0.0:5000", "--no-launch-profile"]

--- a/database/init.sql
+++ b/database/init.sql
@@ -1,0 +1,11 @@
+-- Initialize Chefify database
+-- This script runs before the recipes.sql schema file
+
+-- Create any necessary extensions
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Set timezone
+SET timezone = 'UTC';
+
+-- Create initial user if needed (postgres user should already exist from environment variables)
+-- Additional database setup can be added here as needed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,86 @@
+services:
+  database:
+    image: postgres:15-alpine
+    container_name: chefify-db
+    environment:
+      POSTGRES_DB: chefify
+      POSTGRES_USER: chefify_user
+      POSTGRES_PASSWORD: chefify_password
+      PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./database/init.sql:/docker-entrypoint-initdb.d/00-init.sql
+      - ./recipes.sql:/docker-entrypoint-initdb.d/01-recipes.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U chefify_user -d chefify"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile.dev
+    container_name: chefify-api
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:5000
+      ConnectionStrings__DefaultConnection: "Host=database;Port=5432;Database=chefify;Username=chefify_user;Password=chefify_password;"
+      OIDC__Authority: "https://your-oidc-provider.com"
+      OIDC__ClientId: "chefify-api"
+      OIDC__ClientSecret: "your-client-secret"
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./Chefify.Api:/app/Chefify.Api
+      - ./Chefify.Application:/app/Chefify.Application
+      - ./Chefify.Core:/app/Chefify.Core
+      - ./Chefify.Infrastructure:/app/Chefify.Infrastructure
+      - ./Chefify.sln:/app/Chefify.sln
+      - ./Directory.Build.props:/app/Directory.Build.props
+    depends_on:
+      database:
+        condition: service_healthy
+    develop:
+      watch:
+        - action: sync
+          path: ./Chefify.Api
+          target: /app/Chefify.Api
+        - action: sync
+          path: ./Chefify.Application
+          target: /app/Chefify.Application
+        - action: sync
+          path: ./Chefify.Core
+          target: /app/Chefify.Core
+        - action: sync
+          path: ./Chefify.Infrastructure
+          target: /app/Chefify.Infrastructure
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile.dev
+    container_name: chefify-frontend
+    environment:
+      REACT_APP_API_URL: http://localhost:5000
+      CHOKIDAR_USEPOLLING: true
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    depends_on:
+      - api
+    develop:
+      watch:
+        - action: sync
+          path: ./frontend/src
+          target: /app/src
+        - action: sync
+          path: ./frontend/public
+          target: /app/public
+
+volumes:
+  postgres_data:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,22 @@
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files first for better caching
+COPY frontend/package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the frontend source
+COPY frontend/ .
+
+# Expose port
+EXPOSE 3000
+
+# Enable file watching in containers
+ENV CHOKIDAR_USEPOLLING=true
+
+# Start the development server
+CMD ["npm", "start"]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Complete Docker Compose setup for local development environment
- PostgreSQL 15 Alpine database service with schema initialization
- .NET 8 API service with hot reload support using dotnet watch
- React frontend service ready for development (Dockerfile created)
- Proper volume mounts for hot reload and data persistence
- Environment variable configuration with .env.example

## Features Implemented
- ✅ docker-compose.yml with PostgreSQL, .NET API, and React frontend services
- ✅ backend/Dockerfile.dev for .NET development with hot reload
- ✅ frontend/Dockerfile.dev for React development
- ✅ database/init.sql for Chefify-specific schema initialization  
- ✅ Volume mounts for PostgreSQL data persistence and source code hot reload
- ✅ Existing recipes.sql loaded during database initialization
- ✅ Environment variables for database connection, OIDC, and API URLs
- ✅ .env.example file with all required environment variables
- ✅ Updated README.md with development setup documentation

## Test Plan
- [x] Docker Compose configuration validates successfully
- [x] .NET solution builds without errors
- [ ] Start services with `docker-compose up --build`
- [ ] Verify database initializes with recipes schema
- [ ] Verify API service starts and connects to database
- [ ] Test hot reload functionality for backend changes

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)